### PR TITLE
Fix user notification on access group approval

### DIFF
--- a/cog/views/views_access_control.py
+++ b/cog/views/views_access_control.py
@@ -143,7 +143,7 @@ def ac_process(request, group_name, user_id):
                         
             # notify user
             permissions = registrationService.list(user.profile.openid(), group_name)
-            notifyUser(group_name, request.user, permissions)
+            notifyUser(group_name, user, permissions)
 
             # (GET-POST-REDIRECT)
             return HttpResponseRedirect(reverse('ac_process', kwargs={'user_id': user.id, 'group_name': group_name})


### PR DESCRIPTION
The notification mails were sent to the currently logged in user (i.e. the admin approving the request).
Pass the correct User object (of the approved user) to the notify function so mails will be sent to the approved user.