### PR TITLE
Oauth2 slcs

### DIFF
--- a/cog/backends/esgf.py
+++ b/cog/backends/esgf.py
@@ -1,0 +1,186 @@
+from social_core.backends.oauth import BaseOAuth2
+from social_core.backends.open_id import OpenIdAuth, OPENID_ID_FIELD
+from social_core.exceptions import AuthMissingParameter
+from six.moves.urllib_parse import urlencode, unquote
+
+import os
+from base64 import b64encode
+from OpenSSL import crypto
+from urlparse import urlparse
+
+from openid.yadis.services import getServiceEndpoints
+from openid.yadis.discover import DiscoveryFailure
+
+class ESGFOAuth2(BaseOAuth2):
+    name = 'esgf'
+    AUTHORIZATION_URL = 'https://slcs.ceda.ac.uk/oauth/authorize'
+    ACCESS_TOKEN_URL = 'https://slcs.ceda.ac.uk/oauth/access_token'
+    CERTIFICATE_URL = 'https://slcs.ceda.ac.uk/oauth/certificate/'
+    DEFAULT_SCOPE = ['https://slcs.ceda.ac.uk/oauth/certificate/']
+    REDIRECT_STATE = True
+    ACCESS_TOKEN_METHOD = 'POST'
+    EXTRA_DATA = [
+        ('access_token', 'access_token', True),
+        ('expires_in', 'expires_in', True),
+        ('refresh_token', 'refresh_token', True),
+        ('openid', 'openid', True)
+    ]
+
+
+    def __init__(self, strategy=None, redirect_uri=None):
+        super(ESGFOAuth2, self).__init__(strategy, redirect_uri)
+
+        # Get openid_identifier added to the session by PSA. Requires
+        # SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['openid_identifier',]
+        # set in settings.py
+        if strategy:
+            openid = self.strategy.session_get(OPENID_ID_FIELD, None)
+            self.set_urls(openid)
+
+
+    # get XRDS and extract authorize, access token, and certificate service URLs
+    def set_urls(self, openid):
+        try:
+            uri, endpoints = getServiceEndpoints(openid)
+        except DiscoveryFailure:
+            return
+        for e in endpoints:
+            if e.matchTypes(['urn:esg:security:oauth:endpoint:authorize']):
+                self.AUTHORIZATION_URL = e.uri
+            elif e.matchTypes(['urn:esg:security:oauth:endpoint:access']):
+                self.ACCESS_TOKEN_URL = e.uri
+            elif e.matchTypes(['urn:esg:security:oauth:endpoint:resource']):
+                self.CERTIFICATE_URL = e.uri
+                self.DEFAULT_SCOPE = [e.uri]
+
+
+
+    def get_certificate(self, access_token):
+        """ Generate a new key pair """
+        key_pair = crypto.PKey()
+        key_pair.generate_key(crypto.TYPE_RSA, 2048)
+        self.private_key = crypto.dump_privatekey(crypto.FILETYPE_PEM, key_pair).decode('utf-8')
+
+        """ Generate a certificate request """
+        cert_request = crypto.X509Req()
+        cert_request.set_pubkey(key_pair)
+        cert_request.sign(key_pair, 'md5')
+        cert_request = crypto.dump_certificate_request(crypto.FILETYPE_ASN1, cert_request)
+
+        headers = {'Authorization': 'Bearer {}'.format(access_token)}
+        url = self.CERTIFICATE_URL
+
+        request_args = {'headers': headers,
+                        'data': {'certificate_request': b64encode(cert_request)}
+        }
+        try:
+            response = self.request(url, method='POST', **request_args)
+            response.raise_for_status()
+        except Exception, err:
+            print Exception, err
+        self.cert = response.text
+        cert = crypto.load_certificate(crypto.FILETYPE_PEM, response.text)
+        self.subject = cert.get_subject()
+        return (self.private_key, self.cert, self.subject.commonName)
+
+
+    # TO DO when OIDC is deployed on ESGF IdP nodes
+    # extract user info from id_token (OpenID Connect)
+#    def user_data(self, access_token, *args, **kwargs):
+#        print 'user_data'
+#        response = kwargs.get('response')
+#        id_token = response.get('id_token')
+#        try:
+#            decoded_id_token = jwt_decode(id_token, verify=False)
+#        except (DecodeError, ExpiredSignature) as de:
+#            raise AuthTokenError(self, de)
+#        for key in decoded_id_token:
+#            print '%s:%s' % (key, decoded_id_token[key])
+#
+#        return {'uid': decoded_id_token.get('sub'),
+#                'username': decoded_id_token.get('preferred_username'),
+#                'name': decoded_id_token.get('name'),
+#                'email': decoded_id_token.get('email')
+#                }
+
+
+    # return values that will be stored in the database as:
+    # social_auth_usersocialauth.extra_data['openid'],
+    # auth_user.username
+    def get_user_details(self, response):
+        access_token = response.get('access_token')
+        pkey, cert, openid = self.get_certificate(access_token)
+        username = os.path.basename(urlparse(openid).path)
+        return {'openid': openid,
+                'username': username,
+                }
+
+
+    # PSA compares returned value with social_auth_usersocialauth.uid (provider=='esgf')
+    # if it's new, PSA creates a new user
+    def get_user_id(self, details, response):
+        return details['openid']
+
+
+class ESGFOpenId(OpenIdAuth):
+    name = 'esgf-openid'
+
+    # Extend original openid.openid_url() to a case where openid_identifier is set in the session only
+    def openid_url(self):
+        """Return service provider URL.
+        This base class is generic accepting a POST parameter that specifies
+        provider URL."""
+        if self.URL:
+            return self.URL
+        elif OPENID_ID_FIELD in self.data:
+            return self.data[OPENID_ID_FIELD]
+        elif self.strategy.session_get(OPENID_ID_FIELD, None):
+            return self.strategy.session_get(OPENID_ID_FIELD, None)
+        else:
+            raise AuthMissingParameter(self, OPENID_ID_FIELD)
+
+
+    def get_user_details(self, response):
+        print response.identity_url
+        username = os.path.basename(urlparse(response.identity_url).path)
+        return {'openid': response.identity_url,
+                'username': username,
+                }
+
+
+def associate_by_openid(backend, details, user=None, *args, **kwargs):
+    """
+    Associate current auth with a user with the same social.uid in the DB.
+    """
+
+    if user:
+        return None
+
+    openid = details.get('openid')
+    if openid:
+        # Try to associate accounts registered with the same OpenId.
+        # Probably it is possible to get backend.strategy.storage from kwargs['storage'].
+        if backend.name == 'esgf':
+            social = backend.strategy.storage.user.get_social_auth(provider='esgf-openid', uid=kwargs['uid'])
+        elif backend.name == 'esgf-openid':
+            social = backend.strategy.storage.user.get_social_auth(provider='esgf', uid=kwargs['uid'])
+        if social:
+            return {'user': social.user, 'is_new': False}
+    return None
+
+
+def discover(openid):
+    try:
+        uri, endpoints = getServiceEndpoints(openid)
+    except DiscoveryFailure:
+        return None
+    authorize = None
+    access = None
+    for e in endpoints:
+        if e.matchTypes(['urn:esg:security:oauth:endpoint:authorize']):
+            authorize = True
+        elif e.matchTypes(['urn:esg:security:oauth:endpoint:access']):
+            access = True
+    if authorize and access:
+        return 'OAuth2'
+    return 'OpenID'

--- a/cog/forms/forms_account.py
+++ b/cog/forms/forms_account.py
@@ -52,6 +52,12 @@ class UserOpenidForm(ModelForm):
         fields = ('claimed_id',)
 
 
+class OAuth2LoginForm(Form):
+    
+    openid_identifier = CharField()
+    next = CharField(required=False)
+
+
 class PasswordResetForm(Form):
 
     openid = CharField(required=True, widget=TextInput(attrs={'size': '50'}))

--- a/cog/templates/cog/openid/login.html
+++ b/cog/templates/cog/openid/login.html
@@ -58,7 +58,7 @@
                     var response = JSON.parse(this.responseText);
                     var form = document.getElementById('login_form');
                     if (response.auth == 'OAuth2')
-                        form.action = "{% url 'social:begin' 'esgf' %}";
+                        form.action = "{% url 'oauth2-login' %}";
                     else
                         form.action = "{% url 'openid-login' %}";
                     form.submit();

--- a/cog/templates/cog/openid/login.html
+++ b/cog/templates/cog/openid/login.html
@@ -49,6 +49,25 @@
 		}
 		return true;
 	}
+
+        function submit_form() {
+            var idp = document.getElementById('openid_identifier').value.trim();
+            var xmlhttp = new XMLHttpRequest();
+            xmlhttp.onreadystatechange = function() {
+                if (this.readyState == 4 && this.status == 200) {
+                    var response = JSON.parse(this.responseText);
+                    var form = document.getElementById('login_form');
+                    if (response.auth == 'OAuth2')
+                        form.action = "{% url 'social:begin' 'esgf' %}";
+                    else
+                        form.action = "{% url 'openid-login' %}";
+                    form.submit();
+                }
+            };
+            xmlhttp.open("GET", "{% url 'auth-discover' %}?openid_identifier=" + idp, true);
+            xmlhttp.send();
+            return false;
+        }
 	
 	function init() {
 				
@@ -145,7 +164,7 @@
  	    </div>
  	
 	    <!--Begin login form-->
-	    <form name="fopenid" action="{% url 'openid-login' %}" method="post">
+	    <form name="fopenid" action="" method="post" id="login_form" onsubmit="return submit_form()">
 		    {% csrf_token %}
 		    <div class="mybox">
     	        <table>

--- a/cog/urls.py
+++ b/cog/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     # c) openid-only login
     url(r'^login/$', cog.views.custom_login, {'template_name': 'cog/openid/login.html'}, name='login'),
     url(r'^openid/login/$', django_openid_auth.views.login_begin, {'template_name': 'cog/openid/login.html'}, name='openid-login'),
-    url(r'^oauth2/login/$', cog.views.oauth2_login_view, name='oauth2-login'),
+    url(r'^oauth2/login/$', cog.views.oauth2_login, name='oauth2-login'),
     
     # b) or c)
     #url(r'^openid/complete/$', 'django_openid_auth.views.login_complete', name='openid-complete'),

--- a/cog/urls.py
+++ b/cog/urls.py
@@ -53,7 +53,10 @@ urlpatterns = [
     url(r'^openid/complete/$', cog.views.custom_login_complete, name='openid-complete'),
     url(r'^openid/logo.gif$', django_openid_auth.views.logo, name='openid-logo'),
 
-    
+    # add OAuth2 urls
+    url(r'', include('social_django.urls', namespace='social')),
+    url(r'^esgf-auth/discover/$', cog.views.auth_discover, name='auth-discover'),
+
     # force redirection to login page after logout
     #url(r'^logout/$', 'django.contrib.auth.views.logout_then_login', name='logout'),
     # use next=... to redirect to previous page after logout

--- a/cog/urls.py
+++ b/cog/urls.py
@@ -56,7 +56,7 @@ urlpatterns = [
 
     # add OAuth2 urls
     url(r'', include('social_django.urls', namespace='social')),
-    url(r'^esgf-auth/discover/$', cog.views.auth_discover, name='auth-discover'),
+    url(r'^auth/discover/$', cog.views.auth_discover, name='auth-discover'),
 
     # force redirection to login page after logout
     #url(r'^logout/$', 'django.contrib.auth.views.logout_then_login', name='logout'),

--- a/cog/urls.py
+++ b/cog/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
     # c) openid-only login
     url(r'^login/$', cog.views.custom_login, {'template_name': 'cog/openid/login.html'}, name='login'),
     url(r'^openid/login/$', django_openid_auth.views.login_begin, {'template_name': 'cog/openid/login.html'}, name='openid-login'),
+    url(r'^oauth2/login/$', cog.views.oauth2_login_view, name='oauth2-login'),
     
     # b) or c)
     #url(r'^openid/complete/$', 'django_openid_auth.views.login_complete', name='openid-complete'),

--- a/cog/views/views_account.py
+++ b/cog/views/views_account.py
@@ -136,10 +136,11 @@ def _custom_login(request, response):
     return response
 
 
-def oauth2_login_view(request, form_class=OAuth2LoginForm):
+def oauth2_login(request, form_class=OAuth2LoginForm):
     
     if request.POST:
         
+        # parse the login form
         form = form_class(request.POST)
         if form.is_valid():
             openid_identifier = form.cleaned_data['openid_identifier']
@@ -151,6 +152,7 @@ def oauth2_login_view(request, form_class=OAuth2LoginForm):
             
             return redirect('social:begin', 'esgf')
     
+    # fallback to login view
     return redirect('login')
 
 

--- a/cog/views/views_account.py
+++ b/cog/views/views_account.py
@@ -37,7 +37,7 @@ def redirectToIdp():
 from cog.backends.esgf import discover
 def auth_discover(request, **kwargs):
     openid = request.GET.get('openid_identifier', None)
-    protocol = 'OAuth2'#discover(openid)
+    protocol = discover(openid)
     if protocol == 'OAuth2':
         return JsonResponse({'auth': 'OAuth2'})
     return JsonResponse({'auth': 'OpenID'})

--- a/settings.py
+++ b/settings.py
@@ -194,6 +194,8 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.request',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
                 'cog.context_processors.cog_settings',
             ],
             'debug': DEBUG,
@@ -233,6 +235,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'captcha',
     'layouts',
+    'social_django',
     'cog.apps.CogConfig',
     'cog.templatetags',
 )
@@ -241,8 +244,31 @@ MIGRATION_MODULES = { 'django_openid_auth': 'cog.db_migrations.django_openid_aut
 
 AUTHENTICATION_BACKENDS = (
     'django_openid_auth.auth.OpenIDBackend',
+    'cog.backends.esgf.ESGFOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 )
+
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.auth_allowed',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'cog.backends.esgf.associate_by_openid',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details'
+)
+
+SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['openid_identifier',]
+SOCIAL_AUTH_ESGF_KEY = 'XceQW2eGHpXqTQQsVUtc1UVNiLgoJNdFTZx6cM73'
+SOCIAL_AUTH_ESGF_SECRET = 'qqXpMFz6BuVjiA0QlxovdGUOBycGQhnIPvfyEEuVX81n1k8eNZrGQJC6F4xDzi27DGBqtq6nYp4cCFWG5fJzz3d6derWawGlOfHBKCFg9ZNq75LUyeSWhw0oNkESeztT'
+SOCIAL_AUTH_SANITIZE_REDIRECTS = False
+SOCIAL_AUTH_ESGF_AUTH_EXTRA_ARGUMENTS = {
+    'access_type': 'offline',
+}
+
 
 # Default is X_FRAME_OPTIONS='SAMEORIGIN'
 # Using X_FRAME_OPTIONS = DENY breaks the CKEditor file uploader.

--- a/settings.py
+++ b/settings.py
@@ -262,13 +262,14 @@ SOCIAL_AUTH_PIPELINE = (
 )
 
 SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['openid_identifier',]
-SOCIAL_AUTH_ESGF_KEY = 'XceQW2eGHpXqTQQsVUtc1UVNiLgoJNdFTZx6cM73'
-SOCIAL_AUTH_ESGF_SECRET = 'qqXpMFz6BuVjiA0QlxovdGUOBycGQhnIPvfyEEuVX81n1k8eNZrGQJC6F4xDzi27DGBqtq6nYp4cCFWG5fJzz3d6derWawGlOfHBKCFg9ZNq75LUyeSWhw0oNkESeztT'
 SOCIAL_AUTH_SANITIZE_REDIRECTS = False
 SOCIAL_AUTH_ESGF_AUTH_EXTRA_ARGUMENTS = {
     'access_type': 'offline',
 }
-
+ESGF_OAUTH2_SECRET_FILE = os.environ.get(
+    'ESGF_OAUTH2_SECRET_FILE',
+    '/esg/config/.esgf_oauth2.json'
+)
 
 # Default is X_FRAME_OPTIONS='SAMEORIGIN'
 # Using X_FRAME_OPTIONS = DENY breaks the CKEditor file uploader.


### PR DESCRIPTION
Adds support for OAuth2 login via a customisable set of providers. Tested successfully in dev against https://slcs.ceda.ac.uk/.

Uses a copy of the `ESGFOAuth2` backend from [esgf-auth](https://github.com/ESGF/esgf-auth/blob/master/esgf_auth/backends/esgf.py).