### PR TITLE
Remove time consuming check of data cart presence at other sites

### DIFF
--- a/cog/templates/cog/datacart/datacart.html
+++ b/cog/templates/cog/datacart/datacart.html
@@ -23,13 +23,6 @@
 	<style scoped type="text/css">
 		#datacart-table td,th { padding-bottom: 0; padding-top:2px; margin:0; }
 	</style>
-	
-	<!-- function triggered on other datacart selection -->
-	<script type="text/javascript">
-		function handleOtherDataCartSelect(elm) {
-			window.location = elm.value;
-		}
-	</script>
 
 {% endblock %}
 
@@ -40,34 +33,13 @@
     <p>
         <strong>About Data Carts:</strong> You have a Data Cart on every ESGF node you have logged into. This is your
         Data Cart on the <a href="http://{{ site.domain }}">{{ site.domain }} </a> node.
-        {% if datacars.items|length > 0  %}
-            Use the pull down menu below to navigate between Data Carts.
-        {%  endif %}
         The items in this cart will persist until removed.
     </p>
 	<div style="text-align:center; font-weight:bold">
 		
 		<!-- local data cart -->
 		Number of Items (<span id="datacart_size2">{{ datacart.items.all|length }})</span>
-				
-		<!-- remote data carts -->
-		{% if datacarts.items|length > 0 %}
-			&nbsp; | &nbsp;
-            <label for="dataCartSelect">My Other Data Carts</label>
-			<select name="dataCartSelect" id="dataCartSelect" onchange="javascript:handleOtherDataCartSelect(this)">
-				<option id="other_datacart">My Other Data Carts</option>
-				{% for openid, dc in datacarts.items %}
-					{% for site, value in dc.items %}
-						<option id="{{ site_name }}_datacart" 
-								value="http://{{ site.domain }}/datacart/byopenid?openid={{openid}}">
-							{{ site.name }}: {{ value }}
-						</option>
-					{% endfor %}
-				{% endfor %}				
-			</select>
 
-		{% endif %}
-		
 		<!-- link back to search -->
 		{% if request.session.last_search_url %}
 			&nbsp; | &nbsp;

--- a/cog/views/views_datacart.py
+++ b/cog/views/views_datacart.py
@@ -36,21 +36,10 @@ def datacart_display(request, site_id, user_id):
         datacart = DataCart.objects.get(user=user)
     except DataCart.DoesNotExist:
         datacart = None
-        
-    # inspect remote data carts
-    dcs = {}
-    # combine from possible multiple user openids
-    for openid in user.profile.openids():
-        _dcs = getDataCartsForUser(openid)
-        if len(_dcs) > 0:
-            dcs[openid] = {}
-            for site, size in _dcs.items():
-                print site, size
-                dcs[openid][site] = size
-        
+
     return render(request,
                   'cog/datacart/datacart.html', 
-                  {'datacart': datacart, 'datacarts': dcs})    
+                  {'datacart': datacart})    
     
 
 # view to display a user datacart by openid


### PR DESCRIPTION
The removed code performed a query on the `/user/share` path to *every* other known node in the federation. This caused huge delays to simply display a user's datacart. If this feature is strongly desired a new solution should be adopted.