### PR TITLE
Index node usage

### DIFF
--- a/cog/templates/cog/datacart/_datacart_js.html
+++ b/cog/templates/cog/datacart/_datacart_js.html
@@ -96,7 +96,7 @@
 		  // relative path to COG application
 		  // note: cannot execute HTTP requests to other hosts because of javascript security restrictions
 		  // note: do not use django URL tag because it is interpreted before the 'dataset_id', 'index_node' values are known
-		  var url = "/search_files/"+dataset_id+"/"+index_node+"/?limit="+limit
+		  var url = "/search_files/"+dataset_id+"/"+index_node+"/?limit="+limit+"&project="+project
 		          // add optional query filter
 				  + getQueryFilter('GET');
 		  // add optional 'local' shard

--- a/cog/templates/cog/datacart/_datacart_js.html
+++ b/cog/templates/cog/datacart/_datacart_js.html
@@ -96,7 +96,7 @@
 		  // relative path to COG application
 		  // note: cannot execute HTTP requests to other hosts because of javascript security restrictions
 		  // note: do not use django URL tag because it is interpreted before the 'dataset_id', 'index_node' values are known
-		  var url = "/search_files/"+dataset_id+"/"+index_node+"/?limit="+limit+"&project="+project
+		  var url = "/search_files/"+dataset_id+"/"+index_node+"/?limit="+limit
 		          // add optional query filter
 				  + getQueryFilter('GET');
 		  // add optional 'local' shard

--- a/cog/templates/cog/datacart/_wget_js.html
+++ b/cog/templates/cog/datacart/_wget_js.html
@@ -72,8 +72,6 @@
 	  if (shard.length>0) {
 	  	  url += "?shards=" + encodeURI(shard+"/solr");  // "?shards=localhost:8982/solr"
 	  // or target shared "slave" shard only
-	  } else {
-      	  url += "?distrib=false";
 	  }
 	  
 	  // add optional query filter

--- a/cog/views/views_datacart.py
+++ b/cog/views/views_datacart.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404, render
 from django.template import RequestContext
-from djanog.conf import settings
+from django.conf import settings
 from urlparse import urlparse
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseForbidden, HttpResponseNotAllowed
 from django.core.urlresolvers import reverse

--- a/cog/views/views_datacart.py
+++ b/cog/views/views_datacart.py
@@ -1,5 +1,7 @@
 from django.shortcuts import get_object_or_404, render
 from django.template import RequestContext
+from djanog.conf import settings
+from urlparse import urlparse
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseForbidden, HttpResponseNotAllowed
 from django.core.urlresolvers import reverse
 from cog.models import *
@@ -213,7 +215,7 @@ def datacart_wget(request, site_id, user_id):
             if item.identifier in ids:
 
                 # group selected dataset by index_node
-                index_node = item.getValue('index_node')
+                index_node = urlparse(settings.DEFAULT_SEARCH_URL).netloc
                 wget_key = index_node
                 shard = item.getValue('shard')
                 if shard is not None and len(shard.strip())>0:

--- a/cog/views/views_globus.py
+++ b/cog/views/views_globus.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponseForbidden, HttpResponseServerError
@@ -124,11 +125,9 @@ def download(request):
 		shard = request.GET.get('shard', '')
 		if shard is not None and len(shard.strip()) > 0:
 			params.append(('shards', shard+"/solr"))  # '&shards=localhost:8982/solr'
-		else:
-			params.append(("distrib", "false"))
 
 			
-		url = "http://"+index_node+"/esg-search/search?"+urllib.urlencode(params)
+		url = settings.DEFAULT_SEARCH_URL+"?"+urllib.urlencode(params)
 		print 'Searching for files at URL: %s' % url
 		jobj = getJson(url)
 		

--- a/cog/views/views_search.py
+++ b/cog/views/views_search.py
@@ -829,7 +829,12 @@ def search_files(request, dataset_id, index_node):
     
     # maximum number of files to query for
     limit = request.GET.get('limit', 20)
-            
+    project_short_name = request.GET.get('project', None)
+    if project_short_name is not None:
+        project = get_object_or_404(Project, short_name__iexact=project_short_name)
+        endpoint = project.searchprofile.url
+    else:
+        endpoint = 'http://'+index_node+'/esg-search/search/'
     params = [('type', "File"), ('dataset_id', dataset_id),
               ("format", "application/solr+json"), ('offset', '0'), ('limit', limit)]
     
@@ -847,10 +852,8 @@ def search_files(request, dataset_id, index_node):
     shard = request.GET.get('shard', '')
     if shard is not None and len(shard.strip()) > 0:
         params.append(('shards', shard+"/solr"))  # '&shards=localhost:8982/solr'
-    else:
-        params.append(("distrib", "false"))
  
-    url = "http://"+index_node+"/esg-search/search?"+urllib.urlencode(params)
+    url = endpoint+"?"+urllib.urlencode(params)
     print 'Searching for files: URL=%s' % url
     fh = urllib2.urlopen(url)
     response = fh.read().decode("UTF-8")

--- a/cog/views/views_search.py
+++ b/cog/views/views_search.py
@@ -15,6 +15,7 @@ from cog.services.search import SolrSearchService
 from cog.templatetags.search_utils import displayMetadataKey, formatMetadataKey
 from cog.views.constants import PERMISSION_DENIED_MESSAGE, TEMPLATE_NOT_FOUND_MESSAGE
 from cog.views.utils import getQueryDict
+from django.conf import settings
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
@@ -829,12 +830,6 @@ def search_files(request, dataset_id, index_node):
     
     # maximum number of files to query for
     limit = request.GET.get('limit', 20)
-    project_short_name = request.GET.get('project', None)
-    if project_short_name is not None:
-        project = get_object_or_404(Project, short_name__iexact=project_short_name)
-        endpoint = project.searchprofile.url
-    else:
-        endpoint = 'http://'+index_node+'/esg-search/search/'
     params = [('type', "File"), ('dataset_id', dataset_id),
               ("format", "application/solr+json"), ('offset', '0'), ('limit', limit)]
     
@@ -853,7 +848,7 @@ def search_files(request, dataset_id, index_node):
     if shard is not None and len(shard.strip()) > 0:
         params.append(('shards', shard+"/solr"))  # '&shards=localhost:8982/solr'
  
-    url = endpoint+"?"+urllib.urlencode(params)
+    url = settings.DEFAULT_SEARCH_URL+"?"+urllib.urlencode(params)
     print 'Searching for files: URL=%s' % url
     fh = urllib2.urlopen(url)
     response = fh.read().decode("UTF-8")

--- a/cog/views/views_search.py
+++ b/cog/views/views_search.py
@@ -388,11 +388,11 @@ def metadata_display(request, project_short_name):
     config = _getSearchConfig(request, project)
 
     # retrieve result metadata
-    params = [('type', type), ('id', id), ("format", "application/solr+json"), ("distrib", "false")]
+    params = [('type', type), ('id', id), ("format", "application/solr+json")]
     if type == 'File':
         params.append(('dataset_id', dataset_id))
                 
-    url = "http://"+index_node+"/esg-search/search?"+urllib.urlencode(params)
+    url = project.searchprofile.url+"?"+urllib.urlencode(params)
     print 'Metadata Solr search URL=%s' % url
     fh = urllib2.urlopen(url)
     response = fh.read().decode("UTF-8")
@@ -404,8 +404,8 @@ def metadata_display(request, project_short_name):
     # retrieve parent metadata    
     parentMetadata = {}
     if type == 'File':
-        params = [('type', 'Dataset'), ('id', dataset_id), ("format", "application/solr+json"), ("distrib", "false")]
-        url = "http://"+index_node+"/esg-search/search?"+urllib.urlencode(params)
+        params = [('type', 'Dataset'), ('id', dataset_id), ("format", "application/solr+json")]
+        url = project.searchprofile.url+"?"+urllib.urlencode(params)
         # print 'Solr search URL=%s' % url
         fh = urllib2.urlopen(url)
         response = fh.read().decode("UTF-8")


### PR DESCRIPTION
These changes use the `DEFAULT_SEARCH_URL` setting to determine which search API endpoint to use.
The `Project.searchprofile.url` was going to be used, but a specific `Project` object is not available in all the contexts that are needed. 